### PR TITLE
enabled custom access logging for the websocket and http gateways

### DIFF
--- a/lambdas/types/index.ts
+++ b/lambdas/types/index.ts
@@ -20,6 +20,7 @@ export interface NotificationLogType {
   status: string | undefined; //notification created, notification sent, notification recieved
   channel: string; // in-app, email, slack
   message: string;
+  ttl: number;
 }
 
 export interface LogEvent {

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -39,16 +39,6 @@ export class HttpGWStack extends Stack {
       autoDeploy: true,
     });
 
-    // post route for cdkTest
-    httpApi.addRoutes({
-      path: "/cdkTest",
-      methods: [aws_apigatewayv2.HttpMethod.POST],
-      integration: new aws_apigatewayv2_integrations.HttpLambdaIntegration(
-        "PostToLogNotificationThenBroadcast",
-        dynamoLoggerHttp
-      ),
-    });
-
     httpApi.addRoutes({
       path: "/notification",
       methods: [aws_apigatewayv2.HttpMethod.POST],

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -5,6 +5,9 @@ import {
   CfnOutput,
   Stack,
   StackProps,
+  aws_logs,
+  RemovalPolicy,
+  aws_iam,
 } from "aws-cdk-lib";
 import { DynamoLoggingStack } from "./DynamoLoggingStack";
 
@@ -32,11 +35,39 @@ export class HttpGWStack extends Stack {
       apiName: `HttpApi-${stageName}`,
     });
 
+    // creating log group for access logs
+    const logGroup = new aws_logs.LogGroup(this, "HTTPGatewayAccessLogs", {
+      logGroupName: `HTTPGatewayAccessLogs-${stageName}`,
+      removalPolicy: RemovalPolicy.DESTROY,
+      retention: aws_logs.RetentionDays.ONE_MONTH,
+    });
+
+    // create a role for API Gateway
+    const apiGatewayRole = new aws_iam.Role(this, "ApiGatewayLoggingRole", {
+      assumedBy: new aws_iam.ServicePrincipal("apigateway.amazonaws.com"),
+    });
+
+    // Grant API Gateway permissions to write to Cloudwatch logs
+    logGroup.grantWrite(apiGatewayRole);
+
     // set stage
     const stage = new aws_apigatewayv2.CfnStage(this, `${stageName}`, {
       apiId: httpApi.httpApiId,
       stageName: stageName,
       autoDeploy: true,
+      accessLogSettings: {
+        destinationArn: logGroup.logGroupArn,
+        format: JSON.stringify({
+          requestId: "$context.requestId",
+          userAgent: "$context.identity.userAgent",
+          sourceIp: "$context.identity.sourceIp",
+          requestTime: "$context.requestTime",
+          httpMethod: "$context.httpMethod",
+          path: "$context.path",
+          status: "$context.status",
+          responseLength: "$context.responseLength",
+        }),
+      },
     });
 
     httpApi.addRoutes({


### PR DESCRIPTION
For both gateways:

created a log group with a name of HTTPGatewayAccessLogs-${stageName}, WSGatewayAccessLogs-${stageName}. These are the names of the two logs groups that will be created in CloudWatch

created a role for the API Gateway to enable logging

granted the gateways permission to write to the CloudWatch log groups

Suggested testing:
1. deploy cdk
2. connect to the websocket gateway, and send a request to the http gateway
3. Two gateway logs should be spun up on CloudWatch with the above log group names and your dev stage name
4. if you go into the log groups, you should see each http request in the http log group, and see each websocket log for connection, message sent, and disconnection.