### PR TITLE
User preferences enabled

### DIFF
--- a/lambdas/dynamoNotifLogs/dynamoLogger.ts
+++ b/lambdas/dynamoNotifLogs/dynamoLogger.ts
@@ -122,7 +122,7 @@ export const handler: Handler = async (event) => {
     );
 
     await addLog(log);
-    responseData = await getLog(log.user_id, log.created_at);
+    responseData = await getLog(log.log_id, log.notification_id);
 
     // if initial post request
     if (!body.status) {

--- a/lambdas/types/index.ts
+++ b/lambdas/types/index.ts
@@ -20,6 +20,7 @@ export interface NotificationLogType {
   status: string | undefined; //notification created, notification sent, notification recieved
   channel: string; // in-app, email, slack
   message: string;
+  ttl: number;
 }
 
 export interface LogEvent {

--- a/lambdas/websocketGW/saveActiveNotification.ts
+++ b/lambdas/websocketGW/saveActiveNotification.ts
@@ -8,15 +8,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 
-<<<<<<< Updated upstream
-import { NotificationLogType } from "../types";
-=======
-<<<<<<< Updated upstream
-import { NotificationType } from "../types";
-=======
 import { LogEvent, NotificationLogType } from "../types";
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 const dbClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dbClient);
@@ -25,15 +17,6 @@ const lambdaClient = new LambdaClient();
 const ACTIVE_NOTIF_TABLE = process.env.ACTIVE_NOTIF_TABLE;
 const WS_BROADCAST_LAMBDA = process.env.WS_BROADCAST_LAMBDA;
 
-<<<<<<< Updated upstream
-export const handler: Handler = async (log: NotificationLogType) => {
-  const { log_id, channel, ttl, ...notification } = log;
-  // const notification: NotificationType = ;
-=======
-<<<<<<< Updated upstream
-export const handler: Handler = async (body) => {
-  const notification: NotificationType = body;
-=======
 async function sendLog(logEvent: LogEvent) {
   try {
     const command = new InvokeCommand({
@@ -51,9 +34,6 @@ async function sendLog(logEvent: LogEvent) {
 
 export const handler: Handler = async (log: NotificationLogType) => {
   const { log_id, channel, ttl, ...notification } = log;
-  // const notification: NotificationType = ;
->>>>>>> Stashed changes
->>>>>>> Stashed changes
   const user_id = notification.user_id;
 
   // query user preferences table to see if user wants to receive in-app notifiations
@@ -77,7 +57,7 @@ export const handler: Handler = async (log: NotificationLogType) => {
       TableName: ACTIVE_NOTIF_TABLE,
       Item: {
         ...notification,
-        created_at: new Date().toUTCString(),
+        created_at: new Date(notification.created_at).toISOString(),
         status: "unread",
       },
     };

--- a/lambdas/websocketGW/saveActiveNotification.ts
+++ b/lambdas/websocketGW/saveActiveNotification.ts
@@ -8,7 +8,15 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 
+<<<<<<< Updated upstream
 import { NotificationLogType } from "../types";
+=======
+<<<<<<< Updated upstream
+import { NotificationType } from "../types";
+=======
+import { LogEvent, NotificationLogType } from "../types";
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
 const dbClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dbClient);
@@ -17,9 +25,35 @@ const lambdaClient = new LambdaClient();
 const ACTIVE_NOTIF_TABLE = process.env.ACTIVE_NOTIF_TABLE;
 const WS_BROADCAST_LAMBDA = process.env.WS_BROADCAST_LAMBDA;
 
+<<<<<<< Updated upstream
 export const handler: Handler = async (log: NotificationLogType) => {
   const { log_id, channel, ttl, ...notification } = log;
   // const notification: NotificationType = ;
+=======
+<<<<<<< Updated upstream
+export const handler: Handler = async (body) => {
+  const notification: NotificationType = body;
+=======
+async function sendLog(logEvent: LogEvent) {
+  try {
+    const command = new InvokeCommand({
+      FunctionName: process.env.DYNAMO_LOGGER_FN,
+      InvocationType: "Event",
+      Payload: JSON.stringify(logEvent),
+    });
+    const response = await lambdaClient.send(command);
+    return "Log sent to the dynamo logger";
+  } catch (error) {
+    console.log("Error invoking the Lambda function: ", error);
+    return error;
+  }
+}
+
+export const handler: Handler = async (log: NotificationLogType) => {
+  const { log_id, channel, ttl, ...notification } = log;
+  // const notification: NotificationType = ;
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
   const user_id = notification.user_id;
 
   // query user preferences table to see if user wants to receive in-app notifiations
@@ -51,6 +85,27 @@ export const handler: Handler = async (log: NotificationLogType) => {
     const saveNotifCommand = new PutCommand(saveNotifParams);
     const dbResponse = await docClient.send(saveNotifCommand);
 
+    // add log to indicate we added this to list of active notifications
+    const body = {
+      status: "notification queued",
+      user_id,
+      message: notification.message,
+      notification_id: notification.notification_id,
+    };
+
+    const log = {
+      requestContext: {
+        http: {
+          method: "POST",
+        },
+      },
+      body: JSON.stringify(body),
+    };
+
+    await sendLog(log);
+
+    // broadcast to connected client
+    // this next lambda determines whether the user is currently connected
     const lambdaCommand = new InvokeCommand({
       FunctionName: WS_BROADCAST_LAMBDA,
       InvocationType: "Event",

--- a/lambdas/websocketGW/sendInitialData.ts
+++ b/lambdas/websocketGW/sendInitialData.ts
@@ -8,14 +8,31 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
 
-import { NotificationType } from "../types";
-
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
 
 const apiGateway = new ApiGatewayManagementApi({
   endpoint: process.env.WEBSOCKET_ENDPOINT,
 });
+
+// look up connection ID
+async function getConnectionId(user_id: string) {
+  const queryConnIdParams: QueryCommandInput = {
+    TableName: process.env.CONNECTION_TABLE,
+    IndexName: "user_id-index",
+    KeyConditionExpression: "user_id = :user_id",
+    ExpressionAttributeValues: {
+      ":user_id": user_id,
+    },
+    Limit: 1,
+  };
+  const queryConnIdCommand = new QueryCommand(queryConnIdParams);
+  const queryConnIdResult = await docClient.send(queryConnIdCommand);
+
+  return queryConnIdResult.Items && queryConnIdResult.Items.length > 0
+    ? queryConnIdResult.Items[0].connectionId
+    : null;
+}
 
 // look up active notifications
 async function getActiveNotifications(user_id: string) {
@@ -33,10 +50,15 @@ async function getActiveNotifications(user_id: string) {
 }
 
 export const handler: Handler = async (event) => {
-  try {
-    // receive array of notifications
-    let { user_id } = event.payload;
+  const { user_id } = JSON.parse(event.body).payload;
+  if (user_id === "ping") {
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "pong" }),
+    };
+  }
 
+  try {
     // query user preferences table to see if user wants to receive in-app notifiations
     const getCommand = new GetCommand({
       TableName: process.env.USER_PREFERENCES_TABLE,
@@ -52,22 +74,7 @@ export const handler: Handler = async (event) => {
       activeNotifs = await getActiveNotifications(user_id);
     }
 
-    const queryConnIdParams: QueryCommandInput = {
-      TableName: process.env.CONNECTION_TABLE,
-      IndexName: "user_id-index",
-      KeyConditionExpression: "user_id = :user_id",
-      ExpressionAttributeValues: {
-        ":user_id": user_id,
-      },
-      Limit: 1,
-    };
-    const queryConnIdCommand = new QueryCommand(queryConnIdParams);
-    const queryConnIdResult = await docClient.send(queryConnIdCommand);
-
-    const connectionId =
-      queryConnIdResult.Items && queryConnIdResult.Items.length > 0
-        ? queryConnIdResult.Items[0].connectionId
-        : null;
+    const connectionId = await getConnectionId(user_id);
 
     await apiGateway.postToConnection({
       ConnectionId: connectionId,

--- a/lambdas/websocketGW/sendInitialData.ts
+++ b/lambdas/websocketGW/sendInitialData.ts
@@ -1,0 +1,92 @@
+import { Handler } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+  QueryCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
+
+import { NotificationType } from "../types";
+
+const client = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(client);
+
+const apiGateway = new ApiGatewayManagementApi({
+  endpoint: process.env.WEBSOCKET_ENDPOINT,
+});
+
+// look up active notifications
+async function getActiveNotifications(user_id: string) {
+  const queryParams: QueryCommandInput = {
+    TableName: process.env.ACTIVE_NOTIF_TABLE,
+    KeyConditionExpression: "user_id = :user_id",
+    ExpressionAttributeValues: {
+      ":user_id": user_id,
+    },
+    ScanIndexForward: false,
+  };
+  const queryNotifCommand = new QueryCommand(queryParams);
+  const queryNotifResult = await docClient.send(queryNotifCommand);
+  return queryNotifResult;
+}
+
+export const handler: Handler = async (event) => {
+  try {
+    // receive array of notifications
+    let { user_id } = event.payload;
+
+    // query user preferences table to see if user wants to receive in-app notifiations
+    const getCommand = new GetCommand({
+      TableName: process.env.USER_PREFERENCES_TABLE,
+      Key: { user_id },
+    });
+    const response = await docClient.send(getCommand);
+    const preference = response.Item;
+    delete preference?.user_id;
+
+    let activeNotifs;
+
+    if (preference?.in_app) {
+      activeNotifs = await getActiveNotifications(user_id);
+    }
+
+    const queryConnIdParams: QueryCommandInput = {
+      TableName: process.env.CONNECTION_TABLE,
+      IndexName: "user_id-index",
+      KeyConditionExpression: "user_id = :user_id",
+      ExpressionAttributeValues: {
+        ":user_id": user_id,
+      },
+      Limit: 1,
+    };
+    const queryConnIdCommand = new QueryCommand(queryConnIdParams);
+    const queryConnIdResult = await docClient.send(queryConnIdCommand);
+
+    const connectionId =
+      queryConnIdResult.Items && queryConnIdResult.Items.length > 0
+        ? queryConnIdResult.Items[0].connectionId
+        : null;
+
+    await apiGateway.postToConnection({
+      ConnectionId: connectionId,
+      Data: JSON.stringify({
+        topic: "initial_data",
+        notifications: activeNotifs?.Items,
+        preference,
+      }),
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "Messages sent to the user" }),
+    };
+  } catch (error) {
+    console.error("Error broadcasting message:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Failed to broadcast message" }),
+    };
+  }
+};

--- a/lambdas/websocketGW/sendInitialData.ts
+++ b/lambdas/websocketGW/sendInitialData.ts
@@ -68,11 +68,7 @@ export const handler: Handler = async (event) => {
     const preference = response.Item;
     delete preference?.user_id;
 
-    let activeNotifs;
-
-    if (preference?.in_app) {
-      activeNotifs = await getActiveNotifications(user_id);
-    }
+    const activeNotifs = await getActiveNotifications(user_id);
 
     const connectionId = await getConnectionId(user_id);
 

--- a/lambdas/websocketGW/updateNotification.ts
+++ b/lambdas/websocketGW/updateNotification.ts
@@ -5,13 +5,38 @@ import {
   QueryCommand,
   UpdateCommand,
   DeleteCommand,
+  QueryCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 import { UpdatedNotificationType, LogEvent } from "../types";
+import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
 
-const lambdaClient = new LambdaClient();
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
+const lambdaClient = new LambdaClient();
+
+const apiGateway = new ApiGatewayManagementApi({
+  endpoint: process.env.WEBSOCKET_ENDPOINT,
+});
+
+// look up connection ID
+async function getConnectionId(user_id: string) {
+  const queryConnIdParams: QueryCommandInput = {
+    TableName: process.env.CONNECTION_TABLE,
+    IndexName: "user_id-index",
+    KeyConditionExpression: "user_id = :user_id",
+    ExpressionAttributeValues: {
+      ":user_id": user_id,
+    },
+    Limit: 1,
+  };
+  const queryConnIdCommand = new QueryCommand(queryConnIdParams);
+  const queryConnIdResult = await docClient.send(queryConnIdCommand);
+
+  return queryConnIdResult.Items && queryConnIdResult.Items.length > 0
+    ? queryConnIdResult.Items[0].connectionId
+    : null;
+}
 
 async function sendLog(logEvent: LogEvent) {
   try {
@@ -53,6 +78,7 @@ export const handler: Handler = async (event) => {
     const { created_at, message } = item;
 
     let response, result;
+    const connectionId = await getConnectionId(user_id);
 
     switch (status) {
       case "read":
@@ -72,14 +98,29 @@ export const handler: Handler = async (event) => {
           },
         };
 
-        const updateCommand = new UpdateCommand(updateParams);
-        result = await docClient.send(updateCommand);
+        try {
+          const updateCommand = new UpdateCommand(updateParams);
+          result = await docClient.send(updateCommand);
 
-        response = {
-          statusCode: 200,
-          body: JSON.stringify(result),
-        };
+          await apiGateway.postToConnection({
+            ConnectionId: connectionId,
+            Data: JSON.stringify({
+              topic: "notif_updated",
+              status: "read",
+              notification_id,
+            }),
+          });
 
+          response = {
+            statusCode: 200,
+            body: JSON.stringify(result),
+          };
+        } catch (error) {
+          response = {
+            statusCode: 500,
+            body: JSON.stringify(error),
+          };
+        }
         break;
       case "delete":
         // delete the notification from the active notifications table
@@ -91,13 +132,29 @@ export const handler: Handler = async (event) => {
           },
         };
 
-        const deleteCommand = new DeleteCommand(deleteParams);
-        result = await docClient.send(deleteCommand);
+        try {
+          const deleteCommand = new DeleteCommand(deleteParams);
+          result = await docClient.send(deleteCommand);
 
-        response = {
-          statusCode: 200,
-          body: JSON.stringify(result),
-        };
+          await apiGateway.postToConnection({
+            ConnectionId: connectionId,
+            Data: JSON.stringify({
+              topic: "notif_updated",
+              status: "delete",
+              notification_id,
+            }),
+          });
+
+          response = {
+            statusCode: 200,
+            body: JSON.stringify(result),
+          };
+        } catch (error) {
+          response = {
+            statusCode: 500,
+            body: JSON.stringify(error),
+          };
+        }
 
         break;
       default:

--- a/lambdas/websocketGW/updateNotification.ts
+++ b/lambdas/websocketGW/updateNotification.ts
@@ -50,7 +50,7 @@ export const handler: Handler = async (event) => {
   if (items.length > 0) {
     // if notification is found
     const item = items[0];
-    const createdAt: string = item.created_at;
+    const { created_at, message } = item;
 
     let response, result;
 
@@ -61,7 +61,7 @@ export const handler: Handler = async (event) => {
           TableName: process.env.ACTIVE_NOTIF_TABLE,
           Key: {
             user_id,
-            created_at: createdAt,
+            created_at: created_at,
           },
           UpdateExpression: "SET #status = :status",
           ExpressionAttributeNames: {
@@ -87,7 +87,7 @@ export const handler: Handler = async (event) => {
           TableName: process.env.ACTIVE_NOTIF_TABLE,
           Key: {
             user_id,
-            created_at: createdAt,
+            created_at: created_at,
           },
         };
 
@@ -111,7 +111,7 @@ export const handler: Handler = async (event) => {
     const body = {
       status,
       user_id,
-      message: "in-app",
+      message,
       notification_id,
     };
 

--- a/lambdas/websocketGW/updatePreference.ts
+++ b/lambdas/websocketGW/updatePreference.ts
@@ -1,0 +1,69 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+  QueryCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
+
+const client = new DynamoDBClient();
+const docClient = DynamoDBDocumentClient.from(client);
+
+const apiGateway = new ApiGatewayManagementApi({
+  endpoint: process.env.WEBSOCKET_ENDPOINT,
+});
+
+// look up connection ID
+async function getConnectionId(user_id: string) {
+  const queryConnIdParams: QueryCommandInput = {
+    TableName: process.env.CONNECTION_TABLE,
+    IndexName: "user_id-index",
+    KeyConditionExpression: "user_id = :user_id",
+    ExpressionAttributeValues: {
+      ":user_id": user_id,
+    },
+    Limit: 1,
+  };
+  const queryConnIdCommand = new QueryCommand(queryConnIdParams);
+  const queryConnIdResult = await docClient.send(queryConnIdCommand);
+
+  return queryConnIdResult.Items && queryConnIdResult.Items.length > 0
+    ? queryConnIdResult.Items[0].connectionId
+    : null;
+}
+
+export const handler = async (event) => {
+  const payload = JSON.parse(event.body).payload;
+  try {
+    const putCommand = new PutCommand({
+      TableName: process.env.USER_PREFERENCES_TABLE,
+      Item: payload,
+    });
+    const response = await docClient.send(putCommand);
+
+    if (response.$metadata.httpStatusCode === 200) {
+      const connectionId = await getConnectionId(payload.user_id);
+
+      await apiGateway.postToConnection({
+        ConnectionId: connectionId,
+        Data: JSON.stringify({
+          topic: "preference",
+          preference: payload,
+        }),
+      });
+    } else {
+      throw new Error("Error updating preference in DynamoDB.");
+    }
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response),
+    };
+  } catch (error) {
+    console.error("Error updating user preferences: ", error);
+    return {
+      statusCode: 500,
+      body: error.message,
+    };
+  }
+};

--- a/lambdas/websocketGW/websocketConnect.ts
+++ b/lambdas/websocketGW/websocketConnect.ts
@@ -2,37 +2,14 @@ import { Handler } from "aws-lambda";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
-  QueryCommand,
-  QueryCommandInput,
   PutCommand,
   PutCommandInput,
 } from "@aws-sdk/lib-dynamodb";
-import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 
 const dbClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dbClient);
-const lambdaClient = new LambdaClient();
 
 const CONNECTION_TABLE = process.env.CONNECTION_TABLE!;
-const ACTIVE_NOTIF_TABLE = process.env.ACTIVE_NOTIF_TABLE!;
-const WS_BROADCAST_LAMBDA = process.env.WS_BROADCAST_LAMBDA!;
-
-// look up active notifications
-async function getActiveNotifications(user_id: string) {
-  const queryParams: QueryCommandInput = {
-    TableName: ACTIVE_NOTIF_TABLE,
-    KeyConditionExpression: "user_id = :user_id",
-    ExpressionAttributeValues: {
-      ":user_id": user_id,
-    },
-    ScanIndexForward: false,
-  };
-  const queryNotifCommand = new QueryCommand(queryParams);
-  const queryNotifResult = await docClient.send(queryNotifCommand);
-  return queryNotifResult;
-}
-
-// send to websocketBroadcast
 
 export const handler: Handler = async (event) => {
   const user_id = event.queryStringParameters.user_id;
@@ -56,23 +33,6 @@ export const handler: Handler = async (event) => {
     };
     const putCommand = new PutCommand(putParams);
     await docClient.send(putCommand);
-
-    // see if there are any active notifications to send out
-    const activeNotifs = await getActiveNotifications(user_id);
-
-    if (activeNotifs.Items!.length > 0) {
-      const lambdaCommand = new InvokeCommand({
-        FunctionName: WS_BROADCAST_LAMBDA,
-        InvocationType: "Event",
-        Payload: JSON.stringify({
-          user_id,
-          connectionId,
-          notifications: activeNotifs.Items,
-        }),
-      });
-
-      await lambdaClient.send(lambdaCommand);
-    }
 
     return {
       statusCode: 200,

--- a/lib/constructs/UserPreferencesDdb.ts
+++ b/lib/constructs/UserPreferencesDdb.ts
@@ -1,0 +1,32 @@
+import { aws_dynamodb, RemovalPolicy } from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export interface CustomProps {
+  stageName: string;
+}
+
+export class UserPreferencesDdb extends Construct {
+  UserPreferencesDdb: aws_dynamodb.TableV2;
+
+  constructor(scope: Construct, id: string, props: CustomProps) {
+    super(scope, id);
+
+    const stageName = props?.stageName || "defaultStage";
+
+    const userPreferencesDdb = new aws_dynamodb.TableV2(
+      this,
+      `UserPreferencesTable-${stageName}`,
+      {
+        tableName: `UserPreferencesTable-${stageName}`,
+        partitionKey: {
+          name: "user_id",
+          type: aws_dynamodb.AttributeType.STRING,
+        },
+        billing: aws_dynamodb.Billing.onDemand(),
+        removalPolicy: RemovalPolicy.DESTROY,
+      }
+    );
+
+    this.UserPreferencesDdb = userPreferencesDdb;
+  }
+}

--- a/lib/stacks/CommonStack.ts
+++ b/lib/stacks/CommonStack.ts
@@ -8,6 +8,7 @@ import {
 import { Construct } from "constructs";
 
 import { NotificationLogDb } from "../constructs/NotificationLogDb";
+import { UserPreferencesDdb } from "../constructs/UserPreferencesDdb";
 
 interface CommonStackProps extends StackProps {
   stageName: string;
@@ -16,6 +17,7 @@ interface CommonStackProps extends StackProps {
 export class CommonStack extends Stack {
   // need to share logging lambda
   public readonly notificationLogsDB: NotificationLogDb;
+  public readonly userPreferencesDdb: UserPreferencesDdb;
 
   constructor(scope: Construct, id: string, props: CommonStackProps) {
     super(scope, id, props);
@@ -30,7 +32,16 @@ export class CommonStack extends Stack {
         stageName,
       }
     );
-
     this.notificationLogsDB = notificationLogsDB;
+
+    // create dynamo db table to hold notification logs
+    const userPreferencesDdb = new UserPreferencesDdb(
+      this,
+      `UserPreferencesTable-${stageName}`,
+      {
+        stageName,
+      }
+    );
+    this.userPreferencesDdb = userPreferencesDdb;
   }
 }

--- a/lib/stacks/DynamoLoggingStack.ts
+++ b/lib/stacks/DynamoLoggingStack.ts
@@ -1,10 +1,4 @@
-import {
-  Stack,
-  StackProps,
-  aws_lambda_nodejs,
-  aws_lambda,
-  Lazy,
-} from "aws-cdk-lib";
+import { Stack, StackProps, aws_lambda_nodejs, aws_lambda } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as path from "path";
 
@@ -13,8 +7,8 @@ import { CommonStack } from "./CommonStack";
 
 interface DynamoLoggingStackProps extends StackProps {
   stageName: string;
-  websocketGwStack: WebSocketGWStack;
   commonStack: CommonStack;
+  websocketGwStack: WebSocketGWStack;
 }
 
 export class DynamoLoggingStack extends Stack {
@@ -25,13 +19,13 @@ export class DynamoLoggingStack extends Stack {
     super(scope, id, props);
 
     const stageName = props.stageName || "defaultStage";
-    const webSocketGWStack = props.websocketGwStack;
     const commonStack = props.commonStack;
+    const websocketGwStack = props.websocketGwStack;
 
     // create dynamoLogger lambda
     const dynamoLoggerHttp = new aws_lambda_nodejs.NodejsFunction(
       this,
-      `dynamoLogger-http-${stageName}`,
+      `dynamoLoggerHttp-${stageName}`,
       {
         runtime: aws_lambda.Runtime.NODEJS_20_X,
         handler: "handler",
@@ -43,7 +37,7 @@ export class DynamoLoggingStack extends Stack {
           NOTIFICATION_LOG_TABLE:
             commonStack.notificationLogsDB.NotificationLogTable.tableName,
           SEND_NOTIFICATION:
-            webSocketGWStack.saveActiveNotification.functionName,
+            websocketGwStack.saveActiveNotification.functionName,
         },
       }
     );
@@ -53,8 +47,6 @@ export class DynamoLoggingStack extends Stack {
     commonStack.notificationLogsDB.NotificationLogTable.grantReadWriteData(
       dynamoLoggerHttp
     );
-
-    // allow dynamoLogger to call saveActiveNotification
-    webSocketGWStack.saveActiveNotification.grantInvoke(dynamoLoggerHttp);
+    websocketGwStack.saveActiveNotification.grantInvoke(dynamoLoggerHttp);
   }
 }

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -27,7 +27,7 @@ export class HttpGWStack extends Stack {
     const stageName = props.stageName || "defaultStage";
     const dynamoLoggingStack = props.dynamoLoggingStack;
 
-    // get logging lambda from s3LoggingStack
+    // get logging lambda from dynamo logging stack
     const dynamoLoggerHttp = dynamoLoggingStack.dynamoLoggerHttp;
 
     // create http api gateway

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-dynamodb": "^3.679.0",
         "@aws-sdk/client-lambda": "^3.680.0",
         "@aws-sdk/client-s3": "^3.679.0",
+        "@aws-sdk/client-ssm": "^3.682.0",
         "@aws-sdk/lib-dynamodb": "^3.679.0",
         "@types/aws-lambda": "^8.10.145",
         "aws-cdk-lib": "2.163.1",
@@ -507,6 +508,315 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.682.0.tgz",
+      "integrity": "sha512-5KXlIfd4IKerUH7vs8tR+TzH2tvw9N86Z6S+dwJ5hPxCOHQODFcNW+uNYU5eywbmsAUTtFE5FMTUJbRzog6Miw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/client-sts": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.682.0.tgz",
+      "integrity": "sha512-PYH9RFUMYLFl66HSBq4tIx6fHViMLkhJHTYJoJONpBs+Td+NwVJ895AdLtDsBIhMS0YseCbPpuyjUCJgsUrwUw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
+      "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/client-sts": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
+      "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-node": "3.682.0",
+        "@aws-sdk/middleware-host-header": "3.679.0",
+        "@aws-sdk/middleware-logger": "3.679.0",
+        "@aws-sdk/middleware-recursion-detection": "3.679.0",
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/region-config-resolver": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@aws-sdk/util-user-agent-browser": "3.679.0",
+        "@aws-sdk/util-user-agent-node": "3.682.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.682.0.tgz",
+      "integrity": "sha512-6eqWeHdK6EegAxqDdiCi215nT3QZPwukgWAYuVxNfJ/5m0/P7fAzF+D5kKVgByUvGJEbq/FEL8Fw7OBe64AA+g==",
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.682.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.682.0.tgz",
+      "integrity": "sha512-HSmDqZcBVZrTctHCT9m++vdlDfJ1ARI218qmZa+TZzzOFNpKWy6QyHMEra45GB9GnkkMmV6unoDSPMuN0AqcMg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.679.0",
+        "@aws-sdk/credential-provider-http": "3.679.0",
+        "@aws-sdk/credential-provider-ini": "3.682.0",
+        "@aws-sdk/credential-provider-process": "3.679.0",
+        "@aws-sdk/credential-provider-sso": "3.682.0",
+        "@aws-sdk/credential-provider-web-identity": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.682.0.tgz",
+      "integrity": "sha512-h7IH1VsWgV6YAJSWWV6y8uaRjGqLY3iBpGZlXuTH/c236NMLaNv+WqCBLeBxkFGUb2WeQ+FUPEJDCD69rgLIkg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.682.0",
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/token-providers": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.682.0.tgz",
+      "integrity": "sha512-7TyvYR9HdGH1/Nq0eeApUTM4izB6rExiw87khVYuJwZHr6FmvIL1FsOVFro/4WlXa0lg4LiYOm/8H8dHv+fXTg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.679.0",
+        "@aws-sdk/types": "3.679.0",
+        "@aws-sdk/util-endpoints": "3.679.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.682.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.682.0.tgz",
+      "integrity": "sha512-so5s+j0gPoTS0HM4HPL+G0ajk0T6cQAg8JXzRgvyiQAxqie+zGCZAV3VuVeMNWMVbzsgZl0pYZaatPFTLG/AxA==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.682.0",
+        "@aws-sdk/types": "3.679.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/client-dynamodb": "^3.679.0",
     "@aws-sdk/client-lambda": "^3.680.0",
     "@aws-sdk/client-s3": "^3.679.0",
+    "@aws-sdk/client-ssm": "^3.682.0",
     "@aws-sdk/lib-dynamodb": "^3.679.0",
     "@types/aws-lambda": "^8.10.145",
     "aws-cdk-lib": "2.163.1",


### PR DESCRIPTION
* User preferences table added on AWS
* websocket gateway sends a response back to client when client-side changes are made to preferences or notification status
* `functionName` of some lambda functions are now loosely pre-defined to avoid resource names not being defined yet at deploy time.

Most of the logic regarding adding logs to the dynamo table will eventually migrate to use a queue (SQS), so possible issues there can be disregarded for now.