### PR TITLE
fix: pass user id and created at as arguments to getLog function

### DIFF
--- a/lambdas/dynamoNotifLogs/dynamoLogger.ts
+++ b/lambdas/dynamoNotifLogs/dynamoLogger.ts
@@ -122,7 +122,7 @@ export const handler: Handler = async (event) => {
     );
 
     await addLog(log);
-    responseData = await getLog(log.log_id, log.notification_id);
+    responseData = await getLog(log.user_id, log.created_at);
 
     // if initial post request
     if (!body.status) {


### PR DESCRIPTION
The schema for notification logs was updated to use `user_id` and `created_at` as partition key and sort key, however this change was not reflected in the invocation to retrieve a specific log so the query returned `undefined`. This PR updates the invocation to pass the correct arguments to the function.