### PR TITLE
feat: added httpAuthorizer to httpGW

### DIFF
--- a/lambdas/httpGW/httpAuthorizer.ts
+++ b/lambdas/httpGW/httpAuthorizer.ts
@@ -1,0 +1,5 @@
+export const handler = async (event) => {
+  return {
+    isAuthorized: event.headers.authorization === process.env.SECRET_KEY,
+  };
+};


### PR DESCRIPTION
Added lambda authorization to all HTTP GW routes.

Must manually enter `process.env.SECRET_KEY` for the `httpAuthorizer` lambda for now.

All HTTP requests must included the header `Authorization: {secretKey}`.