### PR TITLE
feat: ws auth calculated hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 cdk.out
+.env

--- a/lambdas/websocketGW/websocketAuthorizer.ts
+++ b/lambdas/websocketGW/websocketAuthorizer.ts
@@ -2,21 +2,21 @@ import { Handler } from "aws-lambda";
 import crypto from "node:crypto";
 
 async function validateHash(
-  userId: string,
+  user_id: string,
   userHash: string
 ): Promise<boolean> {
   let computedHash = crypto
     .createHmac("sha256", process.env.SECRET_KEY)
-    .update(userId)
+    .update(user_id)
     .digest("base64");
 
   return computedHash === userHash;
 }
 
 export const handler: Handler = async function (event, context, callback) {
-  const { userId, userHash } = event.queryStringParameters;
+  const { user_id, userHash } = event.queryStringParameters;
 
-  const authorized = await validateHash(userId, userHash);
+  const authorized = await validateHash(user_id, userHash);
   if (authorized) {
     callback(null, generateAllow("me", event.methodArn));
   } else {

--- a/lib/constructs/UserAttributesDb.ts
+++ b/lib/constructs/UserAttributesDb.ts
@@ -24,16 +24,6 @@ export class UserAttributesDb extends Construct {
         },
         billing: aws_dynamodb.Billing.onDemand(),
         removalPolicy: RemovalPolicy.DESTROY,
-        globalSecondaryIndexes: [
-          {
-            indexName: "userHash-index",
-            partitionKey: {
-              name: "userHash",
-              type: aws_dynamodb.AttributeType.STRING,
-            },
-            projectionType: aws_dynamodb.ProjectionType.ALL,
-          },
-        ],
       }
     );
 

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -85,6 +85,7 @@ export class HttpGWStack extends Stack {
           responseTypes: [
             aws_apigatewayv2_authorizers.HttpLambdaResponseType.SIMPLE,
           ],
+          resultsCacheTtl: Duration.seconds(0),
         }
       );
 

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -17,6 +17,8 @@ import {
 import { DynamoLoggingStack } from "./DynamoLoggingStack";
 import * as path from "path";
 import { CommonStack } from "./CommonStack";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 interface HttpGWStackProps extends StackProps {
   dynamoLoggingStack: DynamoLoggingStack;
@@ -66,7 +68,7 @@ export class HttpGWStack extends Stack {
         handler: "handler",
         entry: path.join(__dirname, "../../lambdas/httpGW/httpAuthorizer.ts"),
         environment: {
-          SECRET_KEY: "",
+          SECRET_KEY: process.env.SECRET_KEY!,
         },
         timeout: Duration.seconds(29),
         memorySize: 256,

--- a/lib/stacks/WebSocketGWStack.ts
+++ b/lib/stacks/WebSocketGWStack.ts
@@ -15,8 +15,9 @@ import * as path from "path";
 
 import { ConnectionIDddb } from "../constructs/ConnectionIDddb";
 import { ActiveNotifDdb } from "../constructs/ActiveNotifDdb";
-
 import { CommonStack } from "./CommonStack";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 interface WebSocketGWStackProps extends StackProps {
   stageName: string;
@@ -275,8 +276,7 @@ export class WebSocketGWStack extends Stack {
           "../../lambdas/websocketGW/websocketAuthorizer.ts"
         ),
         environment: {
-          USER_ATTRIBUTES_TABLE:
-            commonStack.userAttributesDB.UserAttributesTable.tableName,
+          SECRET_KEY: process.env.SECRET_KEY!,
         },
         timeout: Duration.seconds(30),
         memorySize: 256,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "aws-cdk-lib": "2.163.1",
         "aws-sdk": "^2.1691.0",
         "constructs": "^10.0.0",
+        "dotenv": "^16.4.5",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -4634,6 +4635,18 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ejs": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aws-cdk-lib": "2.163.1",
     "aws-sdk": "^2.1691.0",
     "constructs": "^10.0.0",
+    "dotenv": "^16.4.5",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
WebSocket authorizer now generates `computedHash` and verifies that it matches the passed in `userHash` instead of looking up `userHash` from the user attributes table.

`process.env.SECRET_KEY` for http and ws authorizers is now set by using `.env`.

Set http authorizer's cache TTL to 0 (was previously 5 minutes).





