### PR TITLE
fix: missing non-null assertion on sender email identity

### DIFF
--- a/lib/stacks/SesStack.ts
+++ b/lib/stacks/SesStack.ts
@@ -49,7 +49,7 @@ export class SesStack extends Stack {
     );
 
     new aws_ses.CfnEmailIdentity(this, `SenderEmailIdentity-${stageName}`, {
-      emailIdentity: process.env.SENDER_EMAIL,
+      emailIdentity: process.env.SENDER_EMAIL!,
     });
   }
 }


### PR DESCRIPTION
adding the missing non-null operator on the email identity. typescript will not compile if this operator is missing.